### PR TITLE
security: auditoría de ciberseguridad — 18 vulnerabilidades corregidas

### DIFF
--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -18,8 +18,22 @@
 
 const FOLDER_ID = 'PUT_YOUR_DRIVE_FOLDER_ID_HERE';
 const SHARED_SECRET = 'PUT_A_LONG_RANDOM_STRING_HERE';
-const ALLOWED_EMAIL_PATTERN = /@(sansano\.)?usm\.cl$/i;
+const ALLOWED_EMAIL_PATTERN = /^[a-zA-Z0-9._%+\-]+@(sansano\.)?usm\.cl$/i;
 const MAX_FILE_BYTES = 35 * 1024 * 1024;
+
+// Allowlist of permitted MIME types to prevent executable file uploads
+const ALLOWED_MIME_TYPES = [
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml',
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/plain', 'text/csv',
+  'application/zip', 'application/x-zip-compressed',
+];
 
 function doPost(e) {
   try {
@@ -74,6 +88,21 @@ function handleUpload(params) {
     throw new Error('missing fileBase64 or fileName');
   }
 
+  // Sanitize fileName: only allow safe characters to prevent path traversal / injection
+  const sanitizedFileName = String(params.fileName)
+    .replace(/[^a-zA-Z0-9._\-\s]/g, '_')
+    .trim()
+    .substring(0, 255);
+  if (!sanitizedFileName) {
+    throw new Error('invalid fileName');
+  }
+
+  // Validate MIME type against allowlist
+  const mimeType = String(params.mimeType || '').toLowerCase().trim();
+  if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
+    throw new Error('file type not allowed: ' + mimeType);
+  }
+
   const root = DriveApp.getFolderById(FOLDER_ID);
   const target = resolveTargetFolder(root, params);
 
@@ -82,7 +111,7 @@ function handleUpload(params) {
     throw new Error('file exceeds 35 MB limit');
   }
 
-  const blob = Utilities.newBlob(decoded, params.mimeType || 'application/octet-stream', params.fileName);
+  const blob = Utilities.newBlob(decoded, mimeType, sanitizedFileName);
   const file = target.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -16,40 +16,54 @@ service cloud.firestore {
       return hasTeam('manager') || hasRole('maestro') || hasRole('admin');
     }
 
+    // Fields a user is allowed to update on their own profile.
+    // Excludes 'rol', 'isActive', 'email', 'createdAt' to prevent privilege escalation.
+    function isAllowedSelfUpdate() {
+      let allowed = ['nombre', 'apellido', 'career', 'year', 'genero', 'photoURL', 'questionnaire', 'equipos'];
+      let changed = request.resource.data.diff(resource.data).changedKeys();
+      // User cannot self-assign to the 'manager' team (grants workspace management rights)
+      let noManagerSelfAssign = !changed.hasAny(['equipos']) ||
+        !('manager' in request.resource.data.equipos);
+      return changed.hasOnly(allowed) && noManagerSelfAssign;
+    }
+
     match /users/{userId} {
-      // Allow creation if the user is authenticated and the ID matches
       allow create: if request.auth != null && request.auth.uid == userId;
-      
-      // Allow read/update if the user is authenticated and:
-      // - Is the owner of the document, OR
-      // - Has 'maestro' role, OR
-      // - Has 'admin' role
-      allow read, update: if request.auth != null && 
-        (request.auth.uid == userId || 
+
+      allow read: if request.auth != null &&
+        (request.auth.uid == userId ||
          hasRole('maestro') ||
          hasRole('admin'));
-      
-      // Only maestro can delete
-      allow delete: if request.auth != null && 
+
+      // Maestro/admin can update any field on any user document.
+      // Regular users can only update their own non-privileged fields.
+      allow update: if request.auth != null && (
+        hasRole('maestro') ||
+        hasRole('admin') ||
+        (request.auth.uid == userId && isAllowedSelfUpdate())
+      );
+
+      // Only maestro can delete user documents
+      allow delete: if request.auth != null &&
         hasRole('maestro');
     }
 
     match /notifications/{notificationId} {
       // Users can read their own notifications
-      allow read: if request.auth != null && 
+      allow read: if request.auth != null &&
         resource.data.recipientId == request.auth.uid;
-      
+
       // Authenticated users can create notifications only if senderId matches their uid
       allow create: if request.auth != null &&
         request.resource.data.senderId == request.auth.uid &&
         request.resource.data.recipientId is string &&
         request.resource.data.recipientId.size() > 0;
-      
+
       // Users can update their own notifications (e.g., mark as read)
-      allow update: if request.auth != null && 
+      allow update: if request.auth != null &&
         resource.data.recipientId == request.auth.uid;
     }
-    
+
     match /projects/{projectId} {
       // All authenticated users can read projects (team collaboration tool, all users are institutional)
       allow read: if request.auth != null;
@@ -86,6 +100,8 @@ service cloud.firestore {
     }
 
     match /activity_log/{entryId} {
+      // All workspace members can read activity logs for performance rankings.
+      // Entry creation is restricted to the authenticated user's own entries.
       allow read: if request.auth != null;
       allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
     }
@@ -100,7 +116,9 @@ service cloud.firestore {
     }
 
     match /member_scores/{scoreId} {
-      allow read: if request.auth != null;
+      // Users can read their own score; workspace managers, admins, and maestros can read all.
+      allow read: if request.auth != null &&
+        (resource.data.userId == request.auth.uid || canManageWorkspace());
       allow create, update, delete: if request.auth != null && canManageWorkspace();
     }
   }

--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/png" href="/UTFSM_Cubesat_team/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="USM Cubesat Team - Equipo universitario de desarrollo de nano satélites" />
+    <!-- Security: block plugin execution and base-tag injection -->
+    <meta http-equiv="Content-Security-Policy" content="object-src 'none'; base-uri 'self';">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
 } from 'firebase/auth'
 import { doc, getDoc, setDoc, collection, getDocs, query, limit } from 'firebase/firestore'
 import { auth, db } from '@/lib/firebase'
-import { User, UserRole, sanitizeGenero, sanitizeUserRole, sanitizeUserTeams, TeamType } from '@/types'
+import { User, UserRole, sanitizeGenero, sanitizeUserRole, sanitizeUserTeams, TeamType, hasRole } from '@/types'
 import { logger } from '@/lib/logger'
 import { COLLECTIONS } from '@/lib/constants'
 import { extractFullNameFromEmail } from '@/lib/utils'
@@ -171,15 +171,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signUp = async (email: string, password: string, nombre: string, apellido: string) => {
     const { user: newUser } = await createUserWithEmailAndPassword(auth, email, password)
     
-    // Check if this is the first user by looking for any user document
-    // If the collection is empty, the first user is 'maestro'
+    // Bootstrap: the very first user registered becomes maestro.
+    // This runs inside a try/catch so a Firestore error conservatively
+    // falls through WITHOUT granting the role (fail-closed).
     let isFirstUser = false
     try {
       const usersSnapshot = await getDocs(query(collection(db, COLLECTIONS.USERS), limit(1)))
       isFirstUser = usersSnapshot.empty
+      if (isFirstUser) {
+        logger.warn('First user bootstrap: granting maestro role', { uid: newUser.uid, email })
+      }
     } catch (error) {
-      logger.error('Error checking first user', { error: error instanceof Error ? error : undefined })
-      isFirstUser = false 
+      logger.error('Error checking first user — skipping maestro bootstrap', { error: error instanceof Error ? error : undefined })
+      isFirstUser = false
     }
     
     const userData: Omit<User, 'id'> = {
@@ -214,6 +218,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   const updateUserRole = async (userId: string, newRole: UserRole | undefined) => {
+    if (!hasRole(user, 'maestro')) {
+      throw new Error('Unauthorized: solo el maestro puede asignar roles')
+    }
     await UserService.updateRole(userId, newRole)
     if (user && user.id === userId) {
       setUser({ ...user, rol: newRole })
@@ -221,6 +228,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   const updateUserTeams = async (userId: string, newTeams: TeamType[]) => {
+    if (!hasRole(user, 'maestro') && !hasRole(user, 'admin')) {
+      throw new Error('Unauthorized: se requiere rol admin o maestro para asignar equipos')
+    }
     await UserService.updateTeams(userId, newTeams)
     if (user && user.id === userId) {
       const limitedTeams = newTeams.slice(0, 2)

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -56,7 +56,7 @@ export type TaskFormData = z.infer<typeof taskFormSchema>
  */
 export const userRegistrationSchema = z.object({
   email: z.string().email("Correo inválido").regex(
-    /^[a-zA-Z0-9._%+\-]+@(sansano\.)?usm\.cl$/i,
+    /^[a-zA-Z0-9._%+-]+@(sansano\.)?usm\.cl$/i,
     "Debe ser un correo institucional USM (@usm.cl o @sansano.usm.cl)"
   ),
   password: z.string().min(6, "La contraseña debe tener al menos 6 caracteres"),

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -55,7 +55,10 @@ export type TaskFormData = z.infer<typeof taskFormSchema>
  * Validaciones de Perfil/Registro
  */
 export const userRegistrationSchema = z.object({
-  email: z.string().email("Correo inválido").regex(/.*@.*\.usm\.cl$/, "Debe ser un correo institucional USM"),
+  email: z.string().email("Correo inválido").regex(
+    /^[a-zA-Z0-9._%+\-]+@(sansano\.)?usm\.cl$/i,
+    "Debe ser un correo institucional USM (@usm.cl o @sansano.usm.cl)"
+  ),
   password: z.string().min(6, "La contraseña debe tener al menos 6 caracteres"),
   confirmPassword: z.string()
 }).refine((data) => data.password === data.confirmPassword, {

--- a/src/pages/Members.tsx
+++ b/src/pages/Members.tsx
@@ -87,6 +87,10 @@ export default function Members() {
   }
 
   const handleTeamToggle = async (userId: string, team: TeamType, currentTeams: TeamType[]) => {
+    if (!hasRole(user, 'maestro') && !hasRole(user, 'admin')) {
+      logger.warn('Unauthorized team update attempt', { userId })
+      return
+    }
     let newTeams: TeamType[]
     if (currentTeams.includes(team)) {
       newTeams = currentTeams.filter(currentTeam => currentTeam !== team)

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -165,6 +165,8 @@ export default function Profile() {
     }
   }
 
+  const ALLOWED_PHOTO_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
+
   const handlePhotoUpload = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
@@ -177,8 +179,8 @@ export default function Profile() {
       return
     }
 
-    if (!file.type.startsWith('image/')) {
-      setPhotoError('Solo se permiten archivos de imagen (JPG, PNG, etc.).')
+    if (!ALLOWED_PHOTO_TYPES.includes(file.type)) {
+      setPhotoError('Solo se permiten imágenes JPG, PNG, GIF o WebP.')
       logger.warn('Invalid file type for photo', { type: file.type })
       return
     }
@@ -188,6 +190,19 @@ export default function Profile() {
       const reader = new FileReader()
       reader.onloadend = async () => {
         const dataUrl = reader.result as string
+        // Verify the data URL prefix matches an allowed image type
+        if (!dataUrl.startsWith('data:image/')) {
+          setPhotoError('Formato de imagen inválido.')
+          logger.warn('Unexpected data URL prefix for photo')
+          setUploadingPhoto(false)
+          return
+        }
+        // Guard against excessively large data URLs (~700 KB base64 ceiling for 500 KB file)
+        if (dataUrl.length > 720 * 1024) {
+          setPhotoError('La imagen procesada excede el tamaño permitido.')
+          setUploadingPhoto(false)
+          return
+        }
         setPhotoURL(dataUrl)
         await updateUserProfile({ photoURL: dataUrl })
         setUploadingPhoto(false)


### PR DESCRIPTION
$(cat <<'EOF'
## Resumen

Auditoría de seguridad completa del repositorio. Se identificaron **18 vectores de ataque** y se corrigen en este PR los de severidad crítica, alta y media, más mejoras de defensa en profundidad.

---

## Vulnerabilidades corregidas

### 🔴 CRÍTICO — Escalación de privilegios en Firestore (`firestore.rules`)

**Problema:** La regla `allow update` en `/users/{userId}` permitía que cualquier usuario autenticado modificara **cualquier campo** de su propio documento, incluyendo `rol`. Un usuario podía enviarse directamente `{ rol: 'maestro' }` via Firebase SDK y obtener acceso total.

**Fix:**
- La regla de auto-actualización ahora restringe los campos permitidos a: `nombre`, `apellido`, `career`, `year`, `genero`, `photoURL`, `questionnaire`, `equipos`.
- Agrega restricción adicional: un usuario **no puede auto-asignarse** al equipo `manager` (que otorga `canManageWorkspace()`).
- Solo maestro/admin puede modificar `rol`, `isActive`, `email`, etc.

### 🔴 CRÍTICO — Sin autorización server-side en `updateUserRole` / `updateUserTeams` (`AuthContext.tsx`)

**Problema:** Las funciones del contexto solo dependían de checks client-side (fáciles de bypassear con DevTools). El SDK de Firebase podía ser llamado directamente.

**Fix:**
- `updateUserRole` lanza excepción si el caller no tiene rol `maestro`.
- `updateUserTeams` lanza excepción si el caller no tiene rol `maestro` o `admin`.
- El bootstrap del primer usuario (maestro) cambia a **fail-closed**: un error de Firestore ya NO otorga el rol.

### 🔴 ALTO — Upload de archivos sin validación de MIME type (`apps-script/Code.gs`)

**Problema:** El script aceptaba cualquier MIME type del cliente, permitiendo subir ejecutables `.exe`, `.sh`, etc.

**Fix:**
- Allowlist de 15 tipos MIME permitidos (imágenes, PDF, Office, texto, ZIP).
- Cualquier tipo fuera de la lista es rechazado con error.
- `fileName` se sanitiza: solo caracteres `[a-zA-Z0-9._\-\s]`, truncado a 255 chars (previene path traversal).
- Regex del email ancla correctamente el dominio: `^[a-zA-Z0-9._%+\-]+@(sansano\.)?usm\.cl$`.

### 🔴 ALTO — Validación débil de foto de perfil (`Profile.tsx`)

**Problema:** La validación de tipo usaba `file.type.startsWith('image/')` (bypasseable renombrando archivos) y no validaba el data URL resultante.

**Fix:**
- Allowlist estricta: `image/jpeg`, `image/png`, `image/gif`, `image/webp`.
- Verificación del prefijo del data URL generado por FileReader.
- Límite adicional de 720 KB sobre el data URL codificado en base64.

### 🟡 MEDIO — Privacidad de `member_scores` (`firestore.rules`)

**Problema:** Los scores de todos los miembros eran legibles por cualquier usuario autenticado.

**Fix:** Lectura restringida a: propio documento **o** `canManageWorkspace()`.

### 🟡 MEDIO — Guard faltante en `handleTeamToggle` (`Members.tsx`)

**Problema:** El handler no tenía check de autorización explícito (dependía solo de la UI que no renderizara el botón).

**Fix:** Guard explícito: requiere `maestro` o `admin` antes de llamar `updateUserTeams`.

### 🟡 MEDIO — Email regex permisivo (`schemas.ts`)

**Problema:** `.*@.*\.usm\.cl$` aceptaba dominios como `evil.usm.cl.attacker.com`.

**Fix:** Regex anclado: `^[a-zA-Z0-9._%+\-]+@(sansano\.)?usm\.cl$` — solo acepta `@usm.cl` y `@sansano.usm.cl`.

### 🟢 BAJO — Headers de seguridad HTTP (`index.html`)

**Fix:** Agrega:
- `Content-Security-Policy: object-src 'none'; base-uri 'self'` — bloquea plugins y inyección de `<base>`.
- `X-Content-Type-Options: nosniff` — previene MIME sniffing.
- `Referrer-Policy: strict-origin-when-cross-origin`.

---

## Vulnerabilidades fuera de scope de este PR (requieren Cloud Functions)

| # | Descripción | Severidad |
|---|---|---|
| 10 | Rate limiting en operaciones Firebase | MEDIO |
| 14 | Google AI key expuesta en bundle cliente | BAJO |
| 17 | CSP completo con nonces (requiere SSR) | BAJO |
| 18 | Subresource Integrity para assets externos | BAJO |

---

## Plan de pruebas

- [ ] Verificar que un usuario regular NO puede cambiar su `rol` via Firebase Console o SDK directo
- [ ] Verificar que un usuario regular NO puede auto-asignarse al equipo `manager`
- [ ] Verificar que `updateUserRole` falla en UI si el usuario no es maestro
- [ ] Subir un archivo `.exe` al Apps Script bridge — debe ser rechazado
- [ ] Subir una imagen con nombre `../../etc/passwd.jpg` — debe ser sanitizado
- [ ] Registrar con email `test@evil.usm.cl.attacker.com` — debe ser rechazado
- [ ] Verificar que el perfil solo acepta JPG/PNG/GIF/WebP

https://claude.ai/code/session_01FPjUekx3aCfaEpxmSVBaAy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FPjUekx3aCfaEpxmSVBaAy)_