### PR TITLE
security: harden auth model, Drive bridge & CI (full-project audit follow-up)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,13 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
-          VITE_GOOGLE_AI_KEY: ${{ secrets.VITE_GOOGLE_AI_KEY }}
+          # SECURITY: do NOT inject VITE_GOOGLE_AI_KEY or VITE_DRIVE_UPLOAD_SECRET into the
+          # production build. Both are only consumed in DEV-gated code paths, so in a prod
+          # build Vite tree-shakes them away — but if that gate ever regresses, the secret
+          # would be inlined into the public GitHub Pages bundle (this exact footgun already
+          # leaked a Gemini key into git history once). In production the bot routes through
+          # the Apps Script proxy and the Drive secret is fetched at runtime from Firestore.
           VITE_DRIVE_UPLOAD_URL: ${{ secrets.VITE_DRIVE_UPLOAD_URL }}
-          VITE_DRIVE_UPLOAD_SECRET: ${{ secrets.VITE_DRIVE_UPLOAD_SECRET }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -21,6 +21,15 @@ const SHARED_SECRET = 'PUT_A_LONG_RANDOM_STRING_HERE';
 const ALLOWED_EMAIL_PATTERN = /^[a-zA-Z0-9._%+\-]+@(sansano\.)?usm\.cl$/i;
 const MAX_FILE_BYTES = 35 * 1024 * 1024;
 
+// Firebase project id — used to validate the audience (aud) / issuer of ID tokens.
+const FIREBASE_PROJECT_ID = 'usmcubesateam-1e3f4';
+
+// When true, upload/delete REQUIRE a valid Firebase ID token and the trusted email is
+// derived from it, ignoring any client-supplied userEmail. Leave false until the updated
+// web client (which sends params.idToken) is fully deployed, then flip to true to fully
+// close file impersonation. While false, a valid token is still preferred when present.
+const REQUIRE_ID_TOKEN = false;
+
 // Allowlist of Gemini model identifiers accepted by handleChat
 const ALLOWED_MODELS = [
   'gemini-3.5-flash',
@@ -33,7 +42,8 @@ const ALLOWED_MODELS = [
 
 // Allowlist of permitted MIME types to prevent executable file uploads
 const ALLOWED_MIME_TYPES = [
-  'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml',
+  // image/svg+xml intentionally excluded: SVG can carry embedded scripts (stored XSS).
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
   'application/pdf',
   'application/msword',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -94,6 +104,45 @@ function resolveTargetFolder(root, params) {
   return getOrCreateFolder(root, 'general');
 }
 
+/**
+ * Verifies a Firebase ID token via Google's tokeninfo endpoint and returns the
+ * institutional email it asserts, or null if the token is missing/invalid.
+ * Validates audience (this Firebase project), issuer, verified email and domain.
+ */
+function verifyIdToken_(idToken) {
+  if (!idToken) return null;
+  try {
+    const resp = UrlFetchApp.fetch(
+      'https://oauth2.googleapis.com/tokeninfo?id_token=' + encodeURIComponent(String(idToken)),
+      { muteHttpExceptions: true }
+    );
+    if (resp.getResponseCode() !== 200) return null;
+    const claims = JSON.parse(resp.getContentText());
+    if (claims.aud !== FIREBASE_PROJECT_ID) return null;
+    if (claims.iss && claims.iss !== 'https://securetoken.google.com/' + FIREBASE_PROJECT_ID) return null;
+    if (claims.email_verified !== true && claims.email_verified !== 'true') return null;
+    const email = String(claims.email || '').trim().toLowerCase();
+    if (!ALLOWED_EMAIL_PATTERN.test(email)) return null;
+    return email;
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Resolves the trusted email for an upload/delete request. Prefers the verified ID
+ * token; falls back to the (spoofable) client-supplied email only while
+ * REQUIRE_ID_TOKEN is false, for backward compatibility with older clients.
+ */
+function resolveTrustedEmail_(params) {
+  const tokenEmail = verifyIdToken_(params.idToken);
+  if (tokenEmail) return tokenEmail;
+  if (REQUIRE_ID_TOKEN) {
+    throw new Error('valid Firebase ID token required');
+  }
+  return String(params.userEmail || '').trim().toLowerCase();
+}
+
 function handleUpload(params) {
   if (!params.fileBase64 || !params.fileName) {
     throw new Error('missing fileBase64 or fileName');
@@ -126,8 +175,10 @@ function handleUpload(params) {
   const file = target.createFile(blob);
   file.setSharing(DriveApp.Access.ANYONE_WITH_LINK, DriveApp.Permission.VIEW);
 
-  // Store uploader email and deliverableId in description for ownership verification on delete
-  const descParts = ['uploader:' + params.userEmail];
+  // Store the trusted uploader email (from the verified ID token when available) plus the
+  // deliverableId in the description, for ownership verification on delete.
+  const uploaderEmail = resolveTrustedEmail_(params);
+  const descParts = ['uploader:' + uploaderEmail];
   if (params.deliverableId) descParts.push('deliverable:' + params.deliverableId);
   file.setDescription(descParts.join(';'));
 
@@ -147,14 +198,16 @@ function handleDelete(params) {
   }
   const file = DriveApp.getFileById(params.fileId);
 
-  // Verify ownership: only the original uploader may delete via the bridge.
-  // Files uploaded before this check was added (no uploader tag) are allowed
-  // through for backward compatibility.
+  // Verify ownership: only the original uploader may delete via the bridge. The requester
+  // email is derived from the verified Firebase ID token when available (spoof-resistant);
+  // it falls back to the client-supplied email only while REQUIRE_ID_TOKEN is false.
+  // Files uploaded before this check existed (no uploader tag) are allowed through for
+  // backward compatibility.
   const description = file.getDescription() || '';
   const uploaderMatch = description.match(/uploader:([^;]+)/);
   if (uploaderMatch) {
     const uploaderEmail = uploaderMatch[1].trim().toLowerCase();
-    const requesterEmail = (params.userEmail || '').trim().toLowerCase();
+    const requesterEmail = resolveTrustedEmail_(params);
     if (uploaderEmail !== requesterEmail) {
       return { error: 'unauthorized: you can only delete files you uploaded' };
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -28,8 +28,27 @@ service cloud.firestore {
     }
 
     match /users/{userId} {
+      // A user may create ONLY their own profile and may NOT self-assign privileged
+      // fields. Setting 'rol'/'roles' is rejected, 'isActive' can only be true, and the
+      // 'manager' team (which grants workspace management) cannot be self-assigned.
+      // The single exception is the genuine first registrant, who is allowed to bootstrap
+      // as 'maestro' — but only if they are the uid recorded in the bootstrap lock that
+      // the signup transaction created moments earlier. This closes the privilege-
+      // escalation hole where any authenticated user could create their own doc as maestro.
       allow create: if request.auth != null && (
-        request.auth.uid == userId ||
+        (request.auth.uid == userId && (
+          (
+            !request.resource.data.keys().hasAny(['rol', 'roles']) &&
+            (!('isActive' in request.resource.data) || request.resource.data.isActive == true) &&
+            (!('equipos' in request.resource.data) || !('manager' in request.resource.data.equipos))
+          ) ||
+          (
+            exists(/databases/$(database)/documents/users/_bootstrap_lock) &&
+            get(/databases/$(database)/documents/users/_bootstrap_lock).data.maestroUid == request.auth.uid &&
+            request.resource.data.rol == 'maestro' &&
+            (!('equipos' in request.resource.data) || !('manager' in request.resource.data.equipos))
+          )
+        )) ||
         (userId == '_bootstrap_lock' && !exists(/databases/$(database)/documents/users/_bootstrap_lock))
       );
 
@@ -97,7 +116,16 @@ service cloud.firestore {
             'completedBy',
             'completedAt',
             'scoreAwarded'
-          ])
+          ]) &&
+          // Anti-fraude de ranking: un asignado no puede auto-otorgarse un score arbitrario.
+          // Siempre que scoreAwarded esté presente en el documento entrante, debe igualar el
+          // puntaje de importancia fijado por un manager. Si se omite (al revertir la tarea)
+          // o la tarea carece de puntajeImportancia (legado), no se verifica.
+          (
+            !request.resource.data.keys().hasAll(['scoreAwarded']) ||
+            !resource.data.keys().hasAll(['puntajeImportancia']) ||
+            request.resource.data.scoreAwarded == resource.data.puntajeImportancia
+          )
         )
       );
       allow delete: if request.auth != null &&
@@ -106,9 +134,14 @@ service cloud.firestore {
 
     match /activity_log/{entryId} {
       // All workspace members can read activity logs for performance rankings.
-      // Entry creation is restricted to the authenticated user's own entries.
+      // Entry creation is restricted to the authenticated user's own entries, with
+      // basic shape/size validation to prevent log forging with malformed payloads.
       allow read: if request.auth != null;
-      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow create: if request.auth != null &&
+        request.resource.data.userId == request.auth.uid &&
+        request.resource.data.type is string &&
+        request.resource.data.description is string &&
+        request.resource.data.description.size() <= 2000;
     }
 
     match /files/{fileId} {
@@ -145,7 +178,10 @@ service cloud.firestore {
     }
 
     match /system_config/{configId} {
-      allow read: if request.auth != null && (request.auth.token.email.endsWith('@usm.cl') || request.auth.token.email.endsWith('@sansano.usm.cl'));
+      // endsWith() is not a valid Firestore Rules string method; use matches() (full-match
+      // RE2) so the institutional-email check actually evaluates instead of erroring.
+      allow read: if request.auth != null &&
+        request.auth.token.email.matches('.*@(sansano[.])?usm[.]cl');
       allow write: if request.auth != null && (hasRole('maestro') || hasRole('admin'));
     }
   }

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -180,9 +180,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const lockRef = doc(db, COLLECTIONS.USERS, '_bootstrap_lock')
         const lockDoc = await transaction.get(lockRef)
         if (!lockDoc.exists()) {
-          transaction.set(lockRef, { 
+          // Note: the lock is readable by any authenticated user (needed so the signup
+          // transaction can check it), so we intentionally do NOT store the maestro's
+          // email here — only the uid, which the Firestore create rule uses to authorize
+          // the one-time maestro bootstrap.
+          transaction.set(lockRef, {
             maestroUid: newUser.uid,
-            email: email,
             createdAt: new Date()
           })
           isFirstUser = true

--- a/src/sdk/FileService.ts
+++ b/src/sdk/FileService.ts
@@ -50,11 +50,16 @@ const callBridge = async (payload: Record<string, unknown>): Promise<DriveBridge
   if (!secrets.driveUploadUrl || !secrets.driveUploadSecret) {
     throw new Error('drive-bridge-not-configured')
   }
+  // Send a Firebase ID token so the bridge can derive the trusted uploader/owner email
+  // server-side instead of relying on the spoofable client-supplied email.
+  const idToken = auth.currentUser
+    ? await auth.currentUser.getIdToken().catch(() => undefined)
+    : undefined
   // Use text/plain to avoid CORS preflight on Apps Script web apps
   const response = await fetch(secrets.driveUploadUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'text/plain;charset=utf-8' },
-    body: JSON.stringify({ secret: secrets.driveUploadSecret, ...payload }),
+    body: JSON.stringify({ secret: secrets.driveUploadSecret, idToken, ...payload }),
   })
   if (!response.ok) {
     throw new Error(`drive-bridge-http-${response.status}`)

--- a/src/test/e2e/auth.e2e.test.ts
+++ b/src/test/e2e/auth.e2e.test.ts
@@ -4,8 +4,8 @@ import {
   signInWithEmailAndPassword,
   signOut,
 } from 'firebase/auth'
-import { doc, getDoc, setDoc, collection, getDocs, query, limit } from 'firebase/firestore'
-import { getTestFirebase, clearFirestoreData, clearAuthUsers } from '../emulator-config'
+import { doc, getDoc, setDoc } from 'firebase/firestore'
+import { getTestFirebase, clearFirestoreData, clearAuthUsers, bootstrapMaestro } from '../emulator-config'
 
 describe('Auth E2E', () => {
   const { auth, db } = getTestFirebase()
@@ -28,18 +28,8 @@ describe('Auth E2E', () => {
 
     const { user } = await createUserWithEmailAndPassword(auth, email, password)
 
-    // Simulate what signUp does: create user doc
-    const isFirstSnap = await getDocs(query(collection(db, 'users'), limit(1)))
-    const isFirst = isFirstSnap.empty
-
-    await setDoc(doc(db, 'users', user.uid), {
-      email,
-      nombre,
-      apellido,
-      ...(isFirst ? { rol: 'maestro' } : {}),
-      createdAt: new Date(),
-      isActive: true,
-    })
+    // First registrant bootstraps as maestro via the lock (mirrors AuthContext.signUp).
+    await bootstrapMaestro(db, user.uid, email, { nombre, apellido })
 
     const userDoc = await getDoc(doc(db, 'users', user.uid))
     expect(userDoc.exists()).toBe(true)
@@ -53,47 +43,24 @@ describe('Auth E2E', () => {
 
   it('should assign maestro role to the first registered user', async () => {
     const email = 'first.user@usm.cl'
-    const password = 'FirstPass123!'
+    const { user } = await createUserWithEmailAndPassword(auth, email, 'FirstPass123!')
 
-    const { user } = await createUserWithEmailAndPassword(auth, email, password)
-
-    const isFirstSnap = await getDocs(query(collection(db, 'users'), limit(1)))
-    const isFirst = isFirstSnap.empty
-    expect(isFirst).toBe(true)
-
-    await setDoc(doc(db, 'users', user.uid), {
-      email,
-      nombre: 'First',
-      apellido: 'User',
-      rol: 'maestro',
-      createdAt: new Date(),
-      isActive: true,
-    })
+    await bootstrapMaestro(db, user.uid, email, { nombre: 'First', apellido: 'User' })
 
     const userDoc = await getDoc(doc(db, 'users', user.uid))
     expect(userDoc.data()!.rol).toBe('maestro')
   })
 
   it('should not assign maestro role to subsequent users', async () => {
-    // Create first user
+    // First user bootstraps as maestro via the lock.
     const { user: first } = await createUserWithEmailAndPassword(auth, 'first@usm.cl', 'Pass123!')
-    await setDoc(doc(db, 'users', first.uid), {
-      email: 'first@usm.cl',
-      nombre: 'First',
-      apellido: 'User',
-      rol: 'maestro',
-      createdAt: new Date(),
-      isActive: true,
-    })
+    await bootstrapMaestro(db, first.uid, 'first@usm.cl', { nombre: 'First', apellido: 'User' })
 
     await signOut(auth)
 
-    // Create second user
+    // Second user self-creates a plain profile and cannot grant itself maestro
+    // (the create rule rejects rol once the bootstrap lock is held by someone else).
     const { user: second } = await createUserWithEmailAndPassword(auth, 'second@usm.cl', 'Pass123!')
-
-    const isFirstSnap = await getDocs(query(collection(db, 'users'), limit(1)))
-    expect(isFirstSnap.empty).toBe(false)
-
     await setDoc(doc(db, 'users', second.uid), {
       email: 'second@usm.cl',
       nombre: 'Second',

--- a/src/test/e2e/members.e2e.test.ts
+++ b/src/test/e2e/members.e2e.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { createUserWithEmailAndPassword, signOut } from 'firebase/auth'
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut } from 'firebase/auth'
 import { doc, setDoc, getDoc, getDocs, collection } from 'firebase/firestore'
-import { getTestFirebase, clearFirestoreData, clearAuthUsers } from '../emulator-config'
+import { getTestFirebase, clearFirestoreData, clearAuthUsers, bootstrapMaestro } from '../emulator-config'
 import { extractFullNameFromEmail } from '@/lib/utils'
 
 describe('Members E2E', () => {
@@ -12,28 +12,22 @@ describe('Members E2E', () => {
     await clearFirestoreData()
     await clearAuthUsers()
 
-    // Create maestro
+    // Create maestro (secure bootstrap lock)
     const { user } = await createUserWithEmailAndPassword(auth, 'maestro.members@usm.cl', 'Pass123!')
     maestroUid = user.uid
-    await setDoc(doc(db, 'users', maestroUid), {
-      email: 'maestro.members@usm.cl',
-      nombre: 'Maestro',
+    await bootstrapMaestro(db, maestroUid, 'maestro.members@usm.cl', {
       apellido: 'Members',
-      rol: 'maestro',
       equipos: ['tecnico'],
-      createdAt: new Date(),
-      isActive: true,
     })
 
     await signOut(auth)
 
-    // Create regular user
+    // Regular user self-creates a plain profile (cannot self-assign the 'manager' team)
     const { user: regular } = await createUserWithEmailAndPassword(auth, 'regular@usm.cl', 'Pass123!')
     await setDoc(doc(db, 'users', regular.uid), {
       email: 'regular@usm.cl',
       nombre: 'Regular',
       apellido: 'User',
-      equipos: ['manager'],
       createdAt: new Date(),
       isActive: true,
     })
@@ -49,6 +43,13 @@ describe('Members E2E', () => {
       createdAt: new Date(),
       isActive: true,
     })
+
+    await signOut(auth)
+
+    // Maestro grants the 'manager' team to the regular user (only managers/admins/maestros
+    // may assign it — a user cannot self-assign it). Tests then run as maestro.
+    await signInWithEmailAndPassword(auth, 'maestro.members@usm.cl', 'Pass123!')
+    await setDoc(doc(db, 'users', regular.uid), { equipos: ['manager'] }, { merge: true })
   })
 
   afterAll(async () => {
@@ -59,7 +60,9 @@ describe('Members E2E', () => {
 
   it('should list all registered users', async () => {
     const snapshot = await getDocs(collection(db, 'users'))
-    expect(snapshot.size).toBe(3)
+    // Exclude the bootstrap lock sentinel doc that lives in /users.
+    const realUsers = snapshot.docs.filter(d => d.id !== '_bootstrap_lock')
+    expect(realUsers.length).toBe(3)
   })
 
   it('should update user role (maestro assigns admin)', async () => {

--- a/src/test/e2e/notifications.e2e.test.ts
+++ b/src/test/e2e/notifications.e2e.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { createUserWithEmailAndPassword, signOut } from 'firebase/auth'
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut } from 'firebase/auth'
 import {
   doc,
   setDoc,
@@ -11,11 +11,13 @@ import {
   Timestamp,
   query,
   where,
+  type DocumentReference,
 } from 'firebase/firestore'
 import { getTestFirebase, clearFirestoreData, clearAuthUsers } from '../emulator-config'
 
 describe('Notifications E2E', () => {
   const { auth, db } = getTestFirebase()
+  const PW = 'Pass123!'
   let senderUid: string
   let recipientUid: string
 
@@ -24,7 +26,7 @@ describe('Notifications E2E', () => {
     await clearAuthUsers()
 
     // Create sender
-    const { user: sender } = await createUserWithEmailAndPassword(auth, 'sender@usm.cl', 'Pass123!')
+    const { user: sender } = await createUserWithEmailAndPassword(auth, 'sender@usm.cl', PW)
     senderUid = sender.uid
     await setDoc(doc(db, 'users', senderUid), {
       email: 'sender@usm.cl',
@@ -37,7 +39,7 @@ describe('Notifications E2E', () => {
     await signOut(auth)
 
     // Create recipient
-    const { user: recipient } = await createUserWithEmailAndPassword(auth, 'recipient@usm.cl', 'Pass123!')
+    const { user: recipient } = await createUserWithEmailAndPassword(auth, 'recipient@usm.cl', PW)
     recipientUid = recipient.uid
     await setDoc(doc(db, 'users', recipientUid), {
       email: 'recipient@usm.cl',
@@ -48,11 +50,20 @@ describe('Notifications E2E', () => {
     })
   })
 
+  // The notifications rules require the creator to be the sender (senderId == auth.uid)
+  // and only the recipient may read/update their own notifications. Each test therefore
+  // creates as the sender and reads back as the recipient.
+  beforeEach(async () => {
+    await signInWithEmailAndPassword(auth, 'sender@usm.cl', PW)
+  })
+
   afterAll(async () => {
     await signOut(auth)
     await clearFirestoreData()
     await clearAuthUsers()
   })
+
+  const asRecipient = () => signInWithEmailAndPassword(auth, 'recipient@usm.cl', PW)
 
   it('should send a message notification and store it in Firestore', async () => {
     const notifRef = await addDoc(collection(db, 'notifications'), {
@@ -66,6 +77,7 @@ describe('Notifications E2E', () => {
       senderName: 'Sender User',
     })
 
+    await asRecipient()
     const stored = await getDoc(notifRef)
     expect(stored.exists()).toBe(true)
 
@@ -86,8 +98,10 @@ describe('Notifications E2E', () => {
       message: 'Test system notification',
       read: false,
       createdAt: Timestamp.now(),
+      senderId: senderUid,
     })
 
+    await asRecipient()
     expect((await getDoc(notifRef)).data()!.read).toBe(false)
 
     await updateDoc(notifRef, { read: true })
@@ -97,7 +111,6 @@ describe('Notifications E2E', () => {
   })
 
   it('should query notifications for a specific user', async () => {
-    // Add notifications for recipient
     await addDoc(collection(db, 'notifications'), {
       recipientId: recipientUid,
       type: 'task_assigned',
@@ -105,8 +118,10 @@ describe('Notifications E2E', () => {
       message: 'You have been assigned a task',
       read: false,
       createdAt: Timestamp.now(),
+      senderId: senderUid,
     })
 
+    await asRecipient()
     const snapshot = await getDocs(
       query(collection(db, 'notifications'), where('recipientId', '==', recipientUid))
     )
@@ -118,6 +133,7 @@ describe('Notifications E2E', () => {
   })
 
   it('should support all notification types', async () => {
+    const created: { type: string; ref: DocumentReference }[] = []
     for (const type of ['task_assigned', 'message', 'system'] as const) {
       const ref = await addDoc(collection(db, 'notifications'), {
         recipientId: recipientUid,
@@ -126,8 +142,13 @@ describe('Notifications E2E', () => {
         message: `Testing ${type}`,
         read: false,
         createdAt: Timestamp.now(),
+        senderId: senderUid,
       })
+      created.push({ type, ref })
+    }
 
+    await asRecipient()
+    for (const { type, ref } of created) {
       const stored = await getDoc(ref)
       expect(stored.data()!.type).toBe(type)
     }
@@ -142,9 +163,11 @@ describe('Notifications E2E', () => {
       message: 'New task assigned to you',
       read: false,
       createdAt: Timestamp.now(),
+      senderId: senderUid,
       relatedId: taskId,
     })
 
+    await asRecipient()
     const stored = await getDoc(ref)
     expect(stored.data()!.relatedId).toBe(taskId)
   })

--- a/src/test/e2e/profile.e2e.test.ts
+++ b/src/test/e2e/profile.e2e.test.ts
@@ -40,12 +40,14 @@ describe('Profile E2E', () => {
   })
 
   it('should update teams selection', async () => {
+    // A user may self-assign non-privileged teams but NOT the 'manager' team
+    // (that grants workspace management and is reserved for maestro/admin to assign).
     await setDoc(doc(db, 'users', userUid), {
-      equipos: ['tecnico', 'manager'],
+      equipos: ['tecnico', 'relaciones_publicas'],
     }, { merge: true })
 
     const updated = await getDoc(doc(db, 'users', userUid))
-    expect(updated.data()!.equipos).toEqual(['tecnico', 'manager'])
+    expect(updated.data()!.equipos).toEqual(['tecnico', 'relaciones_publicas'])
   })
 
   it('should update genero', async () => {
@@ -95,24 +97,24 @@ describe('Profile E2E', () => {
   })
 
   it('should read another users profile data', async () => {
-    // Create a second user
+    // Create a second user. A user self-creates only a non-privileged profile
+    // (rol cannot be self-assigned on create under the hardened rules).
     await signOut(auth)
     const { user: other } = await createUserWithEmailAndPassword(auth, 'other.profile@usm.cl', 'Pass123!')
     await setDoc(doc(db, 'users', other.uid), {
       email: 'other.profile@usm.cl',
       nombre: 'Other',
       apellido: 'Person',
-      rol: 'admin',
       equipos: ['relaciones_publicas'],
       createdAt: new Date(),
       isActive: true,
     })
 
-    // Read the other user's profile
+    // Read the profile back.
     const otherDoc = await getDoc(doc(db, 'users', other.uid))
     expect(otherDoc.exists()).toBe(true)
     expect(otherDoc.data()!.nombre).toBe('Other')
-    expect(otherDoc.data()!.rol).toBe('admin')
+    expect(otherDoc.data()!.rol).toBeUndefined()
     expect(otherDoc.data()!.equipos).toContain('relaciones_publicas')
   })
 })

--- a/src/test/e2e/projects.e2e.test.ts
+++ b/src/test/e2e/projects.e2e.test.ts
@@ -9,7 +9,7 @@ import {
   addDoc,
   Timestamp,
 } from 'firebase/firestore'
-import { getTestFirebase, clearFirestoreData, clearAuthUsers } from '../emulator-config'
+import { getTestFirebase, clearFirestoreData, clearAuthUsers, bootstrapMaestro } from '../emulator-config'
 
 describe('Projects E2E', () => {
   const { auth, db } = getTestFirebase()
@@ -19,17 +19,10 @@ describe('Projects E2E', () => {
     await clearFirestoreData()
     await clearAuthUsers()
 
-    // Create maestro user
+    // Create maestro user (via the secure bootstrap lock)
     const { user } = await createUserWithEmailAndPassword(auth, 'maestro@usm.cl', 'Pass123!')
     maestroUid = user.uid
-    await setDoc(doc(db, 'users', maestroUid), {
-      email: 'maestro@usm.cl',
-      nombre: 'Maestro',
-      apellido: 'User',
-      rol: 'maestro',
-      createdAt: new Date(),
-      isActive: true,
-    })
+    await bootstrapMaestro(db, maestroUid, 'maestro@usm.cl')
   })
 
   afterAll(async () => {

--- a/src/test/e2e/security-rules.e2e.test.ts
+++ b/src/test/e2e/security-rules.e2e.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  signOut,
+} from 'firebase/auth'
+import { doc, setDoc, getDoc, updateDoc, addDoc, collection, Timestamp } from 'firebase/firestore'
+import { getTestFirebase, clearFirestoreData, clearAuthUsers } from '../emulator-config'
+
+/**
+ * Validates the security-hardening rules added during the cybersecurity audit:
+ *  - users.create cannot self-assign rol/roles, isActive:false or the 'manager' team
+ *  - only the genuine first registrant (matching the bootstrap lock uid) may become maestro
+ *  - an assigned member cannot inflate task scoreAwarded beyond the manager-set importance
+ *  - /mail can only be enqueued by workspace managers
+ */
+describe('Security rules — privilege escalation & integrity', () => {
+  const { auth, db } = getTestFirebase()
+  const PW = 'Pass123!'
+
+  const expectDenied = (p: Promise<unknown>) =>
+    expect(p).rejects.toThrow(/permission|insufficient|denied/i)
+
+  /** Replicates the real signup bootstrap: claim the lock, then create the maestro doc. */
+  async function bootstrapMaestro(email: string): Promise<string> {
+    const { user } = await createUserWithEmailAndPassword(auth, email, PW)
+    await setDoc(doc(db, 'users', '_bootstrap_lock'), {
+      maestroUid: user.uid,
+      createdAt: new Date(),
+    })
+    await setDoc(doc(db, 'users', user.uid), {
+      email,
+      nombre: 'Master',
+      apellido: 'Boot',
+      rol: 'maestro',
+      createdAt: new Date(),
+      isActive: true,
+    })
+    return user.uid
+  }
+
+  beforeEach(async () => {
+    await clearFirestoreData()
+    await clearAuthUsers()
+  })
+
+  afterAll(async () => {
+    await signOut(auth).catch(() => undefined)
+    await clearFirestoreData()
+    await clearAuthUsers()
+  })
+
+  it('allows the genuine first user to bootstrap as maestro', async () => {
+    const uid = await bootstrapMaestro('founder@usm.cl')
+    const snap = await getDoc(doc(db, 'users', uid))
+    expect(snap.data()!.rol).toBe('maestro')
+  })
+
+  it('blocks a normal user from self-assigning rol:maestro on create', async () => {
+    await bootstrapMaestro('boss1@usm.cl')
+    await signOut(auth)
+
+    const { user } = await createUserWithEmailAndPassword(auth, 'attacker@usm.cl', PW)
+    await expectDenied(
+      setDoc(doc(db, 'users', user.uid), {
+        email: 'attacker@usm.cl',
+        nombre: 'Eve',
+        apellido: 'X',
+        rol: 'maestro',
+        createdAt: new Date(),
+        isActive: true,
+      })
+    )
+  })
+
+  it('blocks self-assigning the manager team on create', async () => {
+    await bootstrapMaestro('boss2@usm.cl')
+    await signOut(auth)
+
+    const { user } = await createUserWithEmailAndPassword(auth, 'eve2@usm.cl', PW)
+    await expectDenied(
+      setDoc(doc(db, 'users', user.uid), {
+        email: 'eve2@usm.cl',
+        nombre: 'Eve',
+        apellido: 'X',
+        equipos: ['manager'],
+        createdAt: new Date(),
+        isActive: true,
+      })
+    )
+  })
+
+  it('allows a normal self-create without privileged fields', async () => {
+    await bootstrapMaestro('boss3@usm.cl')
+    await signOut(auth)
+
+    const { user } = await createUserWithEmailAndPassword(auth, 'reg@usm.cl', PW)
+    await setDoc(doc(db, 'users', user.uid), {
+      email: 'reg@usm.cl',
+      nombre: 'Reg',
+      apellido: 'User',
+      equipos: ['tecnico'],
+      createdAt: new Date(),
+      isActive: true,
+    })
+    const snap = await getDoc(doc(db, 'users', user.uid))
+    expect(snap.data()!.rol).toBeUndefined()
+  })
+
+  it('blocks an assigned member from inflating scoreAwarded above puntajeImportancia', async () => {
+    const maestroEmail = 'mgr@usm.cl'
+    await bootstrapMaestro(maestroEmail)
+
+    // Member registers (this signs in as the member) and creates a plain profile.
+    const { user: member } = await createUserWithEmailAndPassword(auth, 'member@usm.cl', PW)
+    const memberUid = member.uid
+    await setDoc(doc(db, 'users', memberUid), {
+      email: 'member@usm.cl',
+      nombre: 'Mem',
+      apellido: 'Ber',
+      createdAt: new Date(),
+      isActive: true,
+    })
+
+    // Maestro creates a task assigned to the member, with importance 5.
+    await signOut(auth)
+    await signInWithEmailAndPassword(auth, maestroEmail, PW)
+    const taskRef = await addDoc(collection(db, 'tasks'), {
+      titulo: 'Test task',
+      descripcion: '',
+      estado: 'pendiente',
+      asignadoA: [memberUid],
+      equipo: 'tecnico',
+      prioridad: 'media',
+      creadoPor: 'maestro',
+      puntajeImportancia: 5,
+      createdAt: Timestamp.now(),
+    })
+
+    // Member tries to self-award an inflated score → must be denied.
+    await signOut(auth)
+    await signInWithEmailAndPassword(auth, 'member@usm.cl', PW)
+    await expectDenied(
+      updateDoc(taskRef, {
+        estado: 'completado',
+        completedBy: memberUid,
+        completedAt: new Date().toISOString(),
+        scoreAwarded: 9999,
+      })
+    )
+
+    // Setting scoreAwarded to the legitimate importance is allowed.
+    await updateDoc(taskRef, {
+      estado: 'completado',
+      completedBy: memberUid,
+      completedAt: new Date().toISOString(),
+      scoreAwarded: 5,
+    })
+    const stored = await getDoc(taskRef)
+    expect(stored.data()!.scoreAwarded).toBe(5)
+  })
+
+  it('blocks a non-manager from enqueuing /mail but allows a maestro', async () => {
+    const maestroEmail = 'mailer@usm.cl'
+    await bootstrapMaestro(maestroEmail)
+
+    // Regular member cannot write to /mail.
+    const { user: member } = await createUserWithEmailAndPassword(auth, 'm2@usm.cl', PW)
+    await setDoc(doc(db, 'users', member.uid), {
+      email: 'm2@usm.cl',
+      nombre: 'M',
+      apellido: 'Two',
+      createdAt: new Date(),
+      isActive: true,
+    })
+    await expectDenied(
+      addDoc(collection(db, 'mail'), {
+        to: 'victim@usm.cl',
+        message: { subject: 'spam', html: 'x' },
+        createdAt: Timestamp.now(),
+      })
+    )
+
+    // Maestro can.
+    await signOut(auth)
+    await signInWithEmailAndPassword(auth, maestroEmail, PW)
+    const ref = await addDoc(collection(db, 'mail'), {
+      to: 'team@usm.cl',
+      message: { subject: 'digest', html: 'x' },
+      createdAt: Timestamp.now(),
+    })
+    expect(ref.id).toBeTruthy()
+  })
+})

--- a/src/test/e2e/tasks.e2e.test.ts
+++ b/src/test/e2e/tasks.e2e.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { createUserWithEmailAndPassword, signOut } from 'firebase/auth'
 import {
-  doc,
   setDoc,
   getDoc,
   getDocs,
@@ -11,7 +10,7 @@ import {
   query,
   where,
 } from 'firebase/firestore'
-import { getTestFirebase, clearFirestoreData, clearAuthUsers } from '../emulator-config'
+import { getTestFirebase, clearFirestoreData, clearAuthUsers, bootstrapMaestro } from '../emulator-config'
 
 describe('Tasks E2E', () => {
   const { auth, db } = getTestFirebase()
@@ -22,17 +21,10 @@ describe('Tasks E2E', () => {
     await clearFirestoreData()
     await clearAuthUsers()
 
-    // Create maestro user
+    // Create maestro user (via the secure bootstrap lock)
     const { user } = await createUserWithEmailAndPassword(auth, 'maestro.tasks@usm.cl', 'Pass123!')
     maestroUid = user.uid
-    await setDoc(doc(db, 'users', maestroUid), {
-      email: 'maestro.tasks@usm.cl',
-      nombre: 'Maestro',
-      apellido: 'Tasks',
-      rol: 'maestro',
-      createdAt: new Date(),
-      isActive: true,
-    })
+    await bootstrapMaestro(db, maestroUid, 'maestro.tasks@usm.cl', { apellido: 'Tasks' })
 
     // Create a project for tasks
     const projectRef = await addDoc(collection(db, 'projects'), {

--- a/src/test/emulator-config.ts
+++ b/src/test/emulator-config.ts
@@ -1,6 +1,12 @@
 import { initializeApp, getApps, deleteApp } from 'firebase/app'
 import { getAuth, connectAuthEmulator } from 'firebase/auth'
-import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore'
+import {
+  getFirestore,
+  connectFirestoreEmulator,
+  doc,
+  setDoc,
+  type Firestore,
+} from 'firebase/firestore'
 
 const TEST_PROJECT_ID = 'cubesat-test'
 
@@ -49,4 +55,34 @@ export async function clearAuthUsers() {
   if (!response.ok) {
     throw new Error(`Failed to clear Auth users: ${response.statusText}`)
   }
+}
+
+/**
+ * Seeds a maestro user the same way the real signup bootstrap does: claim the
+ * one-time `_bootstrap_lock` (recording this uid), then create the user doc with
+ * rol:'maestro'. The hardened Firestore rules only authorize a maestro self-create
+ * when the lock's maestroUid matches, so tests must follow this flow.
+ *
+ * The caller must already be signed in as `uid` (e.g. right after
+ * createUserWithEmailAndPassword). Firestore must be empty (lock absent).
+ */
+export async function bootstrapMaestro(
+  db: Firestore,
+  uid: string,
+  email: string,
+  extra: Record<string, unknown> = {}
+) {
+  await setDoc(doc(db, 'users', '_bootstrap_lock'), {
+    maestroUid: uid,
+    createdAt: new Date(),
+  })
+  await setDoc(doc(db, 'users', uid), {
+    email,
+    nombre: 'Maestro',
+    apellido: 'User',
+    rol: 'maestro',
+    createdAt: new Date(),
+    isActive: true,
+    ...extra,
+  })
 }

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -15,5 +15,12 @@ export default defineConfig({
     testTimeout: 30000,
     hookTimeout: 30000,
     setupFiles: [],
+    // All e2e files share a single Firebase emulator and each clears Firestore in
+    // before hooks. Running files in parallel races on that shared state, so force
+    // fully serial execution for deterministic results.
+    fileParallelism: false,
+    poolOptions: {
+      forks: { singleFork: true },
+    },
   },
 })


### PR DESCRIPTION
Follow-up to #28. Extends the cybersecurity audit to the **whole project** (public repo) and fixes what #28 did not cover. All findings were validated against the Firebase emulator.

## 🔴 Critical — privilege escalation to `maestro`
The `users` **create** rule validated only *who* wrote the doc, not *which* fields. Any authenticated user could `setDoc(users/<uid>, { rol: 'maestro' })` via the SDK and gain full admin (read all PII, manage everyone, write `system_config`). The rule now rejects `rol`/`roles`, `isActive:false` and the `manager` team on self-create; only the uid recorded in the `_bootstrap_lock` may bootstrap as maestro.

## 🟠 High / Medium
- **Drive bridge (`apps-script/Code.gs`)**: verify a **Firebase ID token** (tokeninfo) on `upload`/`delete` and derive the trusted email from it instead of the spoofable client field; this makes the ownership check real. Also removed `image/svg+xml` from the upload allowlist. Gated by `REQUIRE_ID_TOKEN` (default `false` for safe rollout — flip to `true` after deploying client + bridge together).
- **`FileService.ts`**: sends the Firebase ID token with bridge calls.
- **`firestore.rules`**: fixed the `system_config` read rule — `endsWith()` is **not** a valid Rules method and errored at runtime (denying reads → breaking the Drive-secret fetch); replaced with `matches()`. Capped `/tasks` `scoreAwarded` to the manager-set `puntajeImportancia` (anti ranking-inflation). Added `activity_log` create validation.
- **`deploy.yml`**: stopped injecting `VITE_GOOGLE_AI_KEY` / `VITE_DRIVE_UPLOAD_SECRET` into the production build (the footgun that previously leaked a Gemini key into git history).
- **`AuthContext.tsx`**: bootstrap lock no longer stores the maestro email (PII reduction).

## 🧪 Tests / infra
- New **`security-rules.e2e.test.ts`** proves the rule properties against the emulator (no self-maestro, no self-manager, bootstrap works, no score inflation, `/mail` manager-only).
- **`vitest.e2e.config.ts`**: e2e now runs serially (the files share one emulator and were racing).
- Migrated e2e fixtures to seed privileged users via a secure bootstrap helper.

**Verified:** build ✅ · lint (0 errors) ✅ · 198 unit tests ✅ · **44/44 e2e** ✅ (baseline was 8 passing).

## ⚠️ Deploy-time actions (not code)
1. `firestore.rules` already deployed — **re-deploy** to pick up the `endsWith→matches()` fix: `firebase deploy --only firestore:rules`.
2. After deploying the web client **and** the updated `Code.gs`, set `REQUIRE_ID_TOKEN = true` in `Code.gs` to fully close bridge impersonation.
3. Update + redeploy the Apps Script `Code.gs` (the live bridge is still the pre-hardening version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)