### PR TITLE
fix(csp): allow script.googleusercontent.com in connect-src

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="USM Cubesat Team - Equipo universitario de desarrollo de nano satélites" />
     <!-- Security: block plugin execution and base-tag injection -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://*.google.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com wss://*.firebaseio.com https://script.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; object-src 'none'; base-uri 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://*.google.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com wss://*.firebaseio.com https://script.google.com https://script.googleusercontent.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; object-src 'none'; base-uri 'self';">
     <meta http-equiv="X-Content-Type-Options" content="nosniff">
     <meta name="referrer" content="strict-origin-when-cross-origin">
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Problema
Tras desplegar el `Code.gs` endurecido (Versión 4), las subidas de archivos fallan con **Failed to fetch** y este error en consola:

> Connecting to `https://script.googleusercontent.com/macros/echo?...` violates CSP directive: `connect-src ... https://script.google.com`. **The action has been blocked.**

Apps Script redirige las respuestas del bridge a través de `script.googleusercontent.com`, dominio que no estaba en la CSP.

## Fix
Una línea en `index.html`: añadir `https://script.googleusercontent.com` a `connect-src`.

## Verificado
Build ✅ · Lint (0 errores) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)