### PR TITLE
fix(activity-log): strip undefined fields before addDoc

### DIFF
--- a/src/sdk/ActivityLogService.ts
+++ b/src/sdk/ActivityLogService.ts
@@ -16,8 +16,15 @@ const toDate = (value: unknown): Date => {
 export class ActivityLogService {
   static async create(entry: Omit<ActivityLogEntry, 'id' | 'createdAt'>): Promise<string> {
     try {
+      // Firestore rejects `undefined` field values. Omit any undefined keys (e.g.
+      // taskId/projectId/deliverableId when a file is uploaded without associating it
+      // to a task or project) so the activity log entry is written successfully.
+      const sanitized: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(entry)) {
+        if (value !== undefined) sanitized[key] = value
+      }
       const ref = await addDoc(collection(db, COLLECTIONS.ACTIVITY_LOG), {
-        ...entry,
+        ...sanitized,
         createdAt: Timestamp.now(),
       })
       return ref.id


### PR DESCRIPTION
## Problema
Al subir un archivo **sin proyecto ni tarea**, los campos `taskId`/`projectId`/`deliverableId` quedan `undefined`. Firestore rechaza `undefined`:

> FirebaseError: Function addDoc() called with invalid data. Unsupported field value: undefined

El error estaba envuelto en `.catch()`, así que **la subida igual funcionaba**, pero la entrada en `activity_log` se perdía silenciosamente y la consola mostraba el error.

## Fix
En `ActivityLogService.create`, omitir las claves cuyo valor sea `undefined` antes de `addDoc`. Es el punto central, así que cubre a **todos** los llamadores (FileService, TaskService, AdminActionsService, etc.).

## Verificado
Build ✅ · Lint (0 errores) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)